### PR TITLE
Upgrade Jukebox tracklist loader

### DIFF
--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -84,17 +84,19 @@
 
 /obj/item/mod/module/visor/rave/Initialize(mapload)
 	. = ..()
-	var/list/tracks = flist("[global.config.directory]/jukebox_music/sounds/")
-	for(var/sound in tracks)
+
+	var/list/tracks_to_load = flist("[global.config.directory]/jukebox_music/sounds/")
+	for(var/song_file in tracks_to_load)
 		var/datum/track/track = new()
-		track.song_path = file("[global.config.directory]/jukebox_music/sounds/[sound]")
-		var/list/sound_params = splittext(sound,"+")
-		if(length(sound_params) != 3)
+		track.song_path = file("[global.config.directory]/jukebox_music/sounds/[song_file]")
+		var/list/song_data = splittext(song_file,"+")
+		if(song_data.len != 4)
 			continue
-		track.song_name = sound_params[1]
-		track.song_length = text2num(sound_params[2])
-		track.song_beat = text2num(sound_params[3])
-		songs[track.song_name] = track
+		track.song_artist = song_data[1]
+		track.song_title = song_data[2]
+		track.song_length = (text2num(song_data[3]) SECONDS)
+		track.song_beat = ((text2num(song_data[4]) / 60) SECONDS)
+		songs["[track.song_artist] - [track.song_title]"] = track
 	if(length(songs))
 		var/song_name = pick(songs)
 		selection = songs[song_name]
@@ -134,7 +136,7 @@
 /obj/item/mod/module/visor/rave/get_configuration()
 	. = ..()
 	if(length(songs))
-		.["selection"] = add_ui_configuration("Song", "list", selection.song_name, clean_songs())
+		.["selection"] = add_ui_configuration("Song", "list", "[selection.song_artist] - [selection.song_title]", clean_songs())
 
 /obj/item/mod/module/visor/rave/configure_edit(key, value)
 	switch(key)

--- a/modular_skyrat/modules/jukebox/code/dance_machine.dm
+++ b/modular_skyrat/modules/jukebox/code/dance_machine.dm
@@ -12,7 +12,7 @@
 	var/list/songs = list()
 	var/datum/track/selection = null
 	/// Volume of the songs played
-	var/volume = 100
+	var/volume = 50
 
 /obj/machinery/jukebox/disco
 	name = "radiant dance machine mark IV"
@@ -88,14 +88,14 @@
 	data["songs"] = list()
 	for(var/datum/track/S in SSjukeboxes.songs)
 		var/list/track_data = list(
-			name = S.song_name
+			name = "[S.song_artist] - [S.song_title]"
 		)
 		data["songs"] += list(track_data)
 	data["track_selected"] = null
 	data["track_length"] = null
 	data["track_beat"] = null
 	if(selection)
-		data["track_selected"] = selection.song_name
+		data["track_selected"] = "[selection.song_artist] - [selection.song_title]"
 		data["track_length"] = DisplayTimeText(selection.song_length)
 		data["track_beat"] = selection.song_beat
 	data["volume"] = volume
@@ -125,7 +125,7 @@
 				return
 			var/list/available = list()
 			for(var/datum/track/S in SSjukeboxes.songs)
-				available[S.song_name] = S
+				available["[S.song_artist] - [S.song_title]"] = S
 			var/selected = params["track"]
 			if(QDELETED(src) || !selected || !istype(available[selected], /datum/track))
 				return
@@ -218,8 +218,6 @@
 				S.pixel_y = 7
 				S.forceMove(get_turf(src))
 		sleep(0.7 SECONDS)
-	if(selection.song_name == "Engineering's Ultimate High-Energy Hustle")
-		sleep(28 SECONDS)
 	for(var/s in sparkles)
 		var/obj/effect/overlay/sparkles/reveal = s
 		reveal.alpha = 255

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -51,11 +51,11 @@ export const Jukebox = (props, context) => {
               <Box position="relative">
                 <Knob
                   size={3.2}
-                  color={volume >= 25 ? 'red' : 'green'}
+                  color="green"
                   value={volume}
                   unit="%"
                   minValue={0}
-                  maxValue={50}
+                  maxValue={100}
                   step={1}
                   stepPixelSize={1}
                   disabled={active}


### PR DESCRIPTION
* Removed unused and unnecessary AssocID variable
* Changed length and beats to be in seconds and beats-per-minute (BPM) instead of deciseconds
* Added hacked support for "Artist - Title" tracknames
* Fixed a loophole that could be abused to set jukebox volume to 100% via browser edits
* Jukebox volume is abstracted to clients as a 0-100% range, while limited internally

